### PR TITLE
Fix AppState.removeEventListener

### DIFF
--- a/cpx_research_sdk_react_native/src/index.tsx
+++ b/cpx_research_sdk_react_native/src/index.tsx
@@ -252,11 +252,11 @@ let CpxResearch: FunctionComponent<ICpxConfig> = config =>
 
   useEffect(() =>
   {
-    AppState.addEventListener("change", handleAppStateChange);
+    const subscription = AppState.addEventListener("change", handleAppStateChange);
 
     return () =>
     {
-      AppState.removeEventListener("change", handleAppStateChange);
+      subscription.remove();
       stopFetchInterval();
     };
   }, [handleAppStateChange]);


### PR DESCRIPTION
`AppState.removeEventListener("change"` has been removed in recent RN version, and it should be replace with `subscription.remove()`